### PR TITLE
feat(reason): update gitignore

### DIFF
--- a/src/commands/reason.ts
+++ b/src/commands/reason.ts
@@ -40,6 +40,13 @@ export const reason = async ({ name }: CLIProps) => {
     output: `${projectName}/webpack.config.js`,
   })
 
+  // Creating git
+  await execa.command('git init', projectFolder)
+  await overwrite({
+    templateName: 'reason/gitignore',
+    output: `${projectName}/.gitignore`,
+  })
+
   // Install dependencies
   spinner.text = 'Installing dependencies'
   await execa.command('npm install --silent', projectFolder)

--- a/src/templates/reason/gitignore.ejs
+++ b/src/templates/reason/gitignore.ejs
@@ -1,0 +1,17 @@
+# Dependencies
+/node_modules
+
+# Build folders
+/lib/bs
+## CommonJS setup
+/lib/js/src
+/lib/js/__tests__/*.bs.js
+## ES6 setup
+/lib/es6/src
+/lib/es6/__tests__/*.bs.js
+
+# Misc
+.DS_Store
+.merlin
+.bsb.lock
+npm-debug.log

--- a/test/commands/reason.spec.ts
+++ b/test/commands/reason.spec.ts
@@ -65,6 +65,19 @@ test('overwrites base files', async () => {
   })
 })
 
+test('should setup git', async () => {
+  await reason({ name: 'test', flags: {} })
+
+  expect(execa.command).toHaveBeenCalledWith('git init', {
+    cwd: expect.stringMatching(/test/),
+  })
+
+  expect(overwrite).toHaveBeenCalledWith({
+    templateName: 'reason/gitignore',
+    output: 'test/.gitignore',
+  })
+})
+
 test('installs app dependencies', async () => {
   await reason({ name: 'test', flags: {} })
 


### PR DESCRIPTION
Fixes #15, fixes #18 

Handles `.gitignore` for both CommonJS and ES6, if the user wishes to switch between one or the other. Remove Jest snapshots from ignored files.