### PR TITLE
feat(reason): add semantic-release

### DIFF
--- a/src/commands/reason.ts
+++ b/src/commands/reason.ts
@@ -61,6 +61,12 @@ export const reason = async ({ name }: CLIProps) => {
     output: `${projectName}/src/index.js`,
   })
 
+  // Creates .releaserc for @semantic-release
+  await create({
+    templateName: 'reason/releaserc',
+    output: `${projectName}/.releaserc`,
+  })
+
   // Move and overwrite index html
   spinner.text = 'Updating base files'
   await execa.command('mkdir public', projectFolder)

--- a/src/templates/reason/package.json.ejs
+++ b/src/templates/reason/package.json.ejs
@@ -21,6 +21,8 @@
     "reason-react": "0.7.0"
   },
   "devDependencies": {
+    "@semantic-release/changelog": "3.0.4",
+    "@semantic-release/git": "7.0.16",
     "autoprefixer": "9.6.1",
     "bs-platform": "5.0.6",
     "cross-env": "5.2.0",

--- a/src/templates/reason/releaserc.ejs
+++ b/src/templates/reason/releaserc.ejs
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    "@semantic-release/git"
+  ]
+}
+

--- a/test/commands/reason.spec.ts
+++ b/test/commands/reason.spec.ts
@@ -98,6 +98,15 @@ test('create tailwind config', async () => {
   })
 })
 
+test('creates releaserc for semantic release', async () => {
+  await reason({ name: 'test', flags: {} })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'reason/releaserc',
+    output: 'test/.releaserc',
+  })
+})
+
 test('move and replace index.html', async () => {
   await reason({ name: 'test', flags: {} })
 


### PR DESCRIPTION
Fixes #16 

Adds [semantic-release](https://github.com/semantic-release/semantic-release) setup for Reason projects.

It creates a `CHANGELOG.md` instead of releases page