### PR TITLE
feat: make typescript default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,6 +866,18 @@
         "minimist": "^1.2.0"
       }
     },
+    "@iteam/config": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@iteam/config/-/config-12.1.0.tgz",
+      "integrity": "sha512-AELnonDCaBbyGaOHUpZgcMccIHBqYdOD2yeOSGxhbXh9O3NeUxdFGl1jVnuhtv7MvZhWjwVsJhQ+MxwqW3hGSw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.3.1",
+        "constant-case": "2.0.0",
+        "dot-prop": "5.1.0",
+        "is-docker": "2.0.0"
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -3566,6 +3578,16 @@
         "date-now": "^0.1.4"
       }
     },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -3985,6 +4007,15 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "dot-prop": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
+      "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
       }
     },
     "duplexer": {
@@ -6662,6 +6693,12 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+      "dev": true
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6720,6 +6757,12 @@
           }
         }
       }
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -11173,6 +11216,15 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     }
   },
   "devDependencies": {
+    "@iteam/config": "^12.1.0",
     "@semantic-release/changelog": "3.0.4",
     "@semantic-release/git": "7.0.16",
     "@types/app-root-path": "1.2.4",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,7 +10,14 @@ export type Command =
   | 'nvmrc'
   | 'prettier'
 
-export const add = (command: Command) => {
+interface AddProps {
+  command: Command
+  flags: {
+    javascript: boolean
+  }
+}
+
+export const add = ({ command, flags }: AddProps) => {
   switch (command) {
     case 'nvm':
     case 'nvmrc':
@@ -27,7 +34,7 @@ export const add = (command: Command) => {
       prettierrc()
       break
     case 'config':
-      config()
+      config({ javascript: flags.javascript })
       break
     case 'husky':
       husky()

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,12 @@
 import { config, gitignore, jest, nvmrc, prettierrc, husky } from '../tools'
+import { CLIFlags } from '../'
 
-export const init = async () => {
-  await config()
+interface InitProps {
+  flags: CLIFlags
+}
+
+export const init = async ({ flags }: InitProps) => {
+  await config({ javascript: flags.javascript || false })
   await gitignore()
   await prettierrc()
   await jest()

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -1,15 +1,20 @@
 import execa from 'execa'
 import chalk from 'chalk'
-import { CLIProps } from '../'
+import { CLIFlags } from '../'
 
-export const react = async ({ name, flags }: CLIProps) => {
+interface ReactProps {
+  name?: string
+  flags: CLIFlags
+}
+
+export const react = async ({ name, flags }: ReactProps) => {
   console.log(`Creating app ${chalk.blue(name || '')}`)
 
   // Create app
   await execa('npx', [
     'create-react-app',
     name || '.',
-    flags.typescript ? '--typescript' : '',
+    flags.javascript ? '' : '--typescript',
   ])
 
   console.log(chalk.green(`Created app ${name || ''}`))

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,15 @@ import { reason } from './commands/reason'
 import { init } from './commands/init'
 import { snippets, SnippetLanguage, SnippetIDE } from './commands/snippets'
 
+export interface CLIFlags {
+  javascript: boolean
+  ide?: string
+  language?: string
+}
+
 export interface CLIProps {
   name?: string
-  flags: {
-    [name: string]: string
-  }
+  flags: CLIFlags
 }
 
 export const run = (cli: meow.Result) => {
@@ -21,16 +25,16 @@ export const run = (cli: meow.Result) => {
 
   switch (command) {
     case 'init':
-      init()
+      init({ flags: flags as CLIFlags })
       break
     case 'react':
-      react({ name, flags })
+      react({ name, flags: flags as CLIFlags })
       break
     case 'reason':
-      reason({ name, flags })
+      reason({ name, flags: flags as CLIFlags })
       break
     case 'add':
-      add(name as Command)
+      add({ command: name as Command, flags: flags as CLIFlags })
       break
     case 'snippets':
       snippets({
@@ -56,16 +60,20 @@ const cli = meow(
     $ snippets [flags]          Copy snippets to clipboard
 
     Flags
-    --typescript    Typescript app (react)
+    --javascript    JavaScript app (react)
     --ide           IDE for snippets (snippets) 
     --language      Language for snippets (snippets) 
     `,
   {
     flags: {
-      typescript: {
+      javascript: {
         type: 'boolean',
+        default: false,
       },
       ide: {
+        type: 'string',
+      },
+      language: {
         type: 'string',
       },
     },

--- a/src/templates/config/config.ts.ejs
+++ b/src/templates/config/config.ts.ejs
@@ -1,0 +1,22 @@
+import configPackage from '@iteam/config'
+
+interface Foo {
+  bar: 'baz'
+}
+
+export interface Config {
+  foo: Foo
+}
+
+const config = configPackage({
+  file: `${__dirname}/../config.json`,
+  defaults: {
+    foo: {
+      bar: 'baz',
+    },
+  },
+})
+
+export default {
+  foo: config.get('foo'),
+} as Config

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,7 +37,11 @@ export const nvmrc = async () => {
   })
 }
 
-export const config = async () => {
+interface ConfigProps {
+  javascript: boolean
+}
+
+export const config = async ({ javascript }: ConfigProps) => {
   await installPkg('@iteam/config')
   await create({
     templateName: 'config/config.json',
@@ -47,10 +51,19 @@ export const config = async () => {
   try {
     const libFolder = await folderExists('lib')
 
-    if (libFolder.isDirectory()) {
+    if (libFolder.isDirectory() && javascript) {
       await create({
         templateName: 'config/config.js',
         output: 'lib/config.js',
+      })
+
+      return
+    }
+
+    if (libFolder.isDirectory() && !javascript) {
+      await create({
+        templateName: 'config/config.ts',
+        output: 'lib/config.ts',
       })
 
       return
@@ -62,10 +75,19 @@ export const config = async () => {
   try {
     const srcFolder = await folderExists('src')
 
-    if (srcFolder.isDirectory()) {
+    if (srcFolder.isDirectory() && javascript) {
       await create({
         templateName: 'config/config.js',
         output: 'src/config.js',
+      })
+
+      return
+    }
+
+    if (srcFolder.isDirectory() && !javascript) {
+      await create({
+        templateName: 'config/config.ts',
+        output: 'src/config.ts',
       })
 
       return
@@ -76,10 +98,19 @@ export const config = async () => {
 
   createFolder('src')
 
-  await create({
-    templateName: 'config/config.js',
-    output: 'src/config.js',
-  })
+  if (javascript) {
+    await create({
+      templateName: 'config/config.js',
+      output: 'src/config.js',
+    })
+  }
+
+  if (!javascript) {
+    await create({
+      templateName: 'config/config.ts',
+      output: 'src/config.ts',
+    })
+  }
 }
 
 export const husky = async () => {

--- a/test/commands/add.spec.ts
+++ b/test/commands/add.spec.ts
@@ -14,56 +14,56 @@ jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 beforeEach(jest.clearAllMocks)
 
-test('nvm - runs nvmrc tool', async () => {
-  await add('nvm')
+test('nvm - runs nvmrc tool', () => {
+  add({ command: 'nvm', flags: { javascript: false } })
 
   expect(nvmrc).toHaveBeenCalled()
 })
 
-test('nvmrc - runs nvmrc tool', async () => {
-  await add('nvmrc')
+test('nvmrc - runs nvmrc tool', () => {
+  add({ command: 'nvmrc', flags: { javascript: false } })
 
   expect(nvmrc).toHaveBeenCalled()
 })
 
-test('git - runs gitignore tool', async () => {
-  await add('git')
+test('git - runs gitignore tool', () => {
+  add({ command: 'git', flags: { javascript: false } })
 
   expect(gitignore).toHaveBeenCalled()
 })
 
-test('gitignore - runs gitignore tool', async () => {
-  await add('gitignore')
+test('gitignore - runs gitignore tool', () => {
+  add({ command: 'gitignore', flags: { javascript: false } })
 
   expect(gitignore).toHaveBeenCalled()
 })
 
-test('jest - runs jest tool', async () => {
-  await add('jest')
+test('jest - runs jest tool', () => {
+  add({ command: 'jest', flags: { javascript: false } })
 
   expect(jestFn).toHaveBeenCalled()
 })
 
-test('prettier - runs prettier tool', async () => {
-  await add('prettier')
+test('prettier - runs prettier tool', () => {
+  add({ command: 'prettier', flags: { javascript: false } })
 
   expect(prettierrc).toHaveBeenCalled()
 })
 
-test('config - creates config files', async () => {
-  await add('config')
+test('config - creates config files', () => {
+  add({ command: 'config', flags: { javascript: false } })
 
-  expect(config).toHaveBeenCalled()
+  expect(config).toHaveBeenCalledWith({ javascript: false })
 })
 
-test('husky - setup', async () => {
-  await add('husky')
+test('husky - setup', () => {
+  add({ command: 'husky', flags: { javascript: false } })
 
   expect(husky).toHaveBeenCalled()
 })
 
-test('handles unknown command', async () => {
-  await add('__not_valid__')
+test('handles unknown command', () => {
+  add({ command: '__not_valid__', flags: { javascript: false } })
 
   expect(global.console.log).toHaveBeenCalledWith(
     '__not_valid__ is not a valid command'

--- a/test/commands/init.spec.ts
+++ b/test/commands/init.spec.ts
@@ -10,39 +10,49 @@ import {
 
 jest.mock('../../src/tools')
 
-describe('#init', () => {
-  test('should create config', async () => {
-    await init()
+const props = {
+  flags: {},
+}
 
-    expect(config).toHaveBeenCalled()
+describe('#init', () => {
+  test('should create config with typescript', async () => {
+    await init(props)
+
+    expect(config).toHaveBeenCalledWith({ javascript: false })
+  })
+
+  test('should create config with javascript', async () => {
+    await init({ flags: { javascript: true } })
+
+    expect(config).toHaveBeenCalledWith({ javascript: true })
   })
 
   test('should create gitignore', async () => {
-    await init()
+    await init(props)
 
     expect(gitignore).toHaveBeenCalled()
   })
 
   test('should install prettier', async () => {
-    await init()
+    await init(props)
 
     expect(prettierrc).toHaveBeenCalled()
   })
 
   test('should install jest', async () => {
-    await init()
+    await init(props)
 
     expect(jestCreate).toHaveBeenCalled()
   })
 
   test('should create nvmrc', async () => {
-    await init()
+    await init(props)
 
     expect(nvmrc).toHaveBeenCalled()
   })
 
   test('should init husky', async () => {
-    await init()
+    await init(props)
 
     expect(husky).toHaveBeenCalled()
   })

--- a/test/commands/react.spec.ts
+++ b/test/commands/react.spec.ts
@@ -22,24 +22,28 @@ describe('#react', () => {
     await react({ flags: {} })
 
     expect(global.console.log).toHaveBeenCalledWith('Creating app ')
-    expect(execa).toHaveBeenCalledWith('npx', ['create-react-app', '.', ''])
+    expect(execa).toHaveBeenCalledWith('npx', [
+      'create-react-app',
+      '.',
+      '--typescript',
+    ])
     expect(global.console.log).toHaveBeenCalledWith('Created app ')
   })
 
   test('create a CRA app', async () => {
     await react({ name: 'test', flags: {} })
 
-    expect(execa).toHaveBeenCalledWith('npx', ['create-react-app', 'test', ''])
-  })
-
-  test('create a typescript CRA app', async () => {
-    await react({ name: 'test', flags: { typescript: true } })
-
     expect(execa).toHaveBeenCalledWith('npx', [
       'create-react-app',
       'test',
       '--typescript',
     ])
+  })
+
+  test('create a javascript CRA app', async () => {
+    await react({ name: 'test', flags: { javascript: true } })
+
+    expect(execa).toHaveBeenCalledWith('npx', ['create-react-app', 'test', ''])
   })
 
   test('prints success message', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -23,9 +23,15 @@ jest.mock('../src/commands/snippets')
 jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 test('handles init command', () => {
-  run({ input: ['init'], flags: {} })
+  run({ input: ['init'], flags: { javascript: false } })
 
-  expect(init).toHaveBeenCalled()
+  expect(init).toHaveBeenCalledWith({ flags: { javascript: false } })
+})
+
+test('handles init command with javascript', () => {
+  run({ input: ['init'], flags: { javascript: true } })
+
+  expect(init).toHaveBeenCalledWith({ flags: { javascript: true } })
 })
 
 test('handles react command', () => {
@@ -44,9 +50,12 @@ test('handles reason command', () => {
 })
 
 test('handles add command', () => {
-  run({ input: ['add', 'test'], flags: {} })
+  run({ input: ['add', 'test'], flags: { javascript: false } })
 
-  expect(add).toHaveBeenCalledWith('test')
+  expect(add).toHaveBeenCalledWith({
+    command: 'test',
+    flags: { javascript: false },
+  })
 })
 
 test('handles snippet command', () => {

--- a/test/tools/index.spec.ts
+++ b/test/tools/index.spec.ts
@@ -111,8 +111,7 @@ describe('#config', () => {
           isDirectory: jest.fn().mockReturnValue(false),
         })
       )
-
-    await config()
+    await config({ javascript: false })
 
     expect(installPkg).toHaveBeenCalledWith('@iteam/config')
   })
@@ -130,7 +129,7 @@ describe('#config', () => {
         })
       )
 
-    await config()
+    await config({ javascript: true })
 
     expect(create).toHaveBeenCalledWith({
       templateName: 'config/config.js',
@@ -142,7 +141,7 @@ describe('#config', () => {
     })
   })
 
-  test('creates a config in src folder', async () => {
+  test('creates a typescript config in src folder', async () => {
     ;(folderExists as jest.Mock)
       .mockImplementationOnce(() =>
         Promise.resolve({
@@ -155,7 +154,32 @@ describe('#config', () => {
         })
       )
 
-    await config()
+    await config({ javascript: false })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'config/config.ts',
+      output: 'src/config.ts',
+    })
+    expect(create).not.toHaveBeenCalledWith({
+      templateName: 'config/config.ts',
+      output: 'lib/config.ts',
+    })
+  })
+
+  test('creates a javascript config in src folder', async () => {
+    ;(folderExists as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          isDirectory: jest.fn().mockReturnValue(false),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          isDirectory: jest.fn().mockReturnValue(true),
+        })
+      )
+
+    await config({ javascript: true })
 
     expect(create).toHaveBeenCalledWith({
       templateName: 'config/config.js',
@@ -180,7 +204,7 @@ describe('#config', () => {
         })
       )
 
-    await config()
+    await config({ javascript: true })
 
     expect(createFolder).toHaveBeenCalledWith('src')
     expect(create).toHaveBeenCalledWith({
@@ -206,7 +230,7 @@ describe('#config', () => {
         })
       )
 
-    await config()
+    await config({ javascript: false })
 
     expect(create).toHaveBeenCalledWith({
       templateName: 'config/config.json',


### PR DESCRIPTION
Closes #34 

BREAKING CHANGE: Make TypeScript the default for `config` and `react`
commands, with an optional `--javascript` flag