### PR TITLE
feat: add graphql api generator

### DIFF
--- a/__mocks__/chalk.ts
+++ b/__mocks__/chalk.ts
@@ -1,0 +1,4 @@
+export default {
+  blue: (param: string) => param,
+  green: (param: string) => param,
+}

--- a/__mocks__/ora.ts
+++ b/__mocks__/ora.ts
@@ -1,0 +1,3 @@
+export default jest.fn(({ text }) => ({
+  start: jest.fn().mockReturnValue({ text, stop: jest.fn() }),
+}))

--- a/src/commands/graphql.ts
+++ b/src/commands/graphql.ts
@@ -1,0 +1,72 @@
+import chalk from 'chalk'
+import execa from 'execa'
+import ora from 'ora'
+import path from 'path'
+import { husky, jest, nvmrc, prettierrc } from '../tools'
+import { create, createFolder, overwrite } from '../utils/file'
+
+interface GraphQLProps {
+  flags: any
+  name?: string
+}
+
+export const graphql = async ({ name }: GraphQLProps) => {
+  if (!name) {
+    console.log(`No name provided`)
+    return
+  }
+
+  const projectFolder = { cwd: path.join(process.cwd(), name) }
+
+  const spinner = ora({ text: 'Creating folder', color: 'blue' }).start()
+
+  await createFolder(name)
+
+  spinner.text = 'Creating empty git repository'
+
+  await execa.command('git init', projectFolder)
+  await overwrite({
+    templateName: 'graphql/gitignore',
+    output: `${name}/.gitignore`,
+  })
+
+  spinner.text = 'Installing dependencies'
+
+  await create({
+    templateName: 'graphql/package.json',
+    output: `${name}/package.json`,
+    templateData: {
+      name,
+    },
+  })
+  await execa.command('npm install --silent', projectFolder)
+
+  await prettierrc({ cwd: name })
+  await jest({ cwd: name })
+  await nvmrc({ cwd: name })
+  await husky({ cwd: name })
+
+  spinner.text = 'Creating base files'
+
+  await create({
+    templateName: 'graphql/tsconfig.json',
+    output: `${name}/tsconfig.json`,
+  })
+
+  await createFolder(`${name}/lib`)
+
+  await create({
+    templateName: 'graphql/server.ts',
+    output: `${name}/lib/server.ts`,
+  })
+
+  spinner.stop()
+
+  console.log(chalk.green(`Created app ${name}`))
+  console.log(`
+  Start the API by running:
+
+  * ${chalk.green(`cd ${name}`)}
+  * ${chalk.green('npm run dev')} (starts API on port 4000)
+  `)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ const cli = meow(
     $ react <name> [flags]      Creates a React app (CRA)
     $ reason <name>             Creates a ReasonReact app
     $ snippets [flags]          Copy snippets to clipboard
+    $ graphql <name>            Create a GraphQL API
 
     Flags
     --javascript    JavaScript app (react)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { add, Command } from './commands/add'
 import { reason } from './commands/reason'
 import { init } from './commands/init'
 import { snippets, SnippetLanguage, SnippetIDE } from './commands/snippets'
+import { graphql } from './commands/graphql'
 
 export interface CLIFlags {
   javascript: boolean
@@ -41,6 +42,9 @@ export const run = (cli: meow.Result) => {
         language: flags.language as SnippetLanguage,
         ide: flags.ide as SnippetIDE,
       })
+      break
+    case 'graphql':
+      graphql({ name, flags: flags as CLIFlags })
       break
     default:
       console.log(help)

--- a/src/templates/graphql/gitignore.ejs
+++ b/src/templates/graphql/gitignore.ejs
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+
+# env
+.env
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Distribution folders
+build
+dist
+
+# Dependency directories
+node_modules
+
+# Local stuff
+.merlin
+.vscode
+config.json
+
+# mac
+.bsb.lock
+.DS_Store
+.rts2_cache_cjs
+.rts2_cache_esm

--- a/src/templates/graphql/package.json.ejs
+++ b/src/templates/graphql/package.json.ejs
@@ -1,0 +1,23 @@
+{
+  "name": "<%= name %>",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "dev": "ts-node-dev --no-notify lib/server.ts"
+  },
+  "keywords": ["graphql", "apollo"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "apollo-server-express": "2.9.4",
+    "express": "4.17.1"
+  },
+  "devDependencies": {
+    "ts-node-dev": "1.0.0-pre.43",
+    "typescript": "3.6.3"
+  }
+}

--- a/src/templates/graphql/server.ts.ejs
+++ b/src/templates/graphql/server.ts.ejs
@@ -1,0 +1,25 @@
+import express from 'express'
+import { ApolloServer, gql } from 'apollo-server-express'
+
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: () => 'Hello world!',
+  },
+}
+
+const server = new ApolloServer({ typeDefs, resolvers })
+
+const app = express()
+
+server.applyMiddleware({ app })
+
+app.listen({ port: 4000 }, () =>
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+)
+

--- a/src/templates/graphql/tsconfig.json.ejs
+++ b/src/templates/graphql/tsconfig.json.ejs
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "build",
+    "rootDir": ".",
+    "sourceMap": true,
+    "target": "esnext",
+    "strict": true
+  }
+}
+

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,10 @@
 import { create, createFolder, folderExists, installPkg } from '../utils/file'
 import execa from 'execa'
 
+interface ToolProps {
+  cwd?: string
+}
+
 export const gitignore = async () => {
   await create({
     templateName: 'gitignore',
@@ -8,31 +12,31 @@ export const gitignore = async () => {
   })
 }
 
-export const prettierrc = async () => {
-  await installPkg('prettier')
+export const prettierrc = async (options: ToolProps = {}) => {
+  await installPkg('prettier', options)
 
   await create({
     templateName: 'prettierrc',
-    output: '.prettierrc',
+    output: options.cwd ? `${options.cwd}/.prettierrc` : '.prettierrc',
   })
 }
 
-export const jest = async () => {
-  await installPkg('jest')
-  await installPkg('jest-watch-typeahead')
+export const jest = async (options: ToolProps = {}) => {
+  await installPkg('jest', options)
+  await installPkg('jest-watch-typeahead', options)
 
   await create({
     templateName: 'jest.config',
-    output: 'jest.config.js',
+    output: options.cwd ? `${options.cwd}/jest.config.js` : 'jest.config.js',
   })
 }
 
-export const nvmrc = async () => {
+export const nvmrc = async (options: ToolProps = {}) => {
   const { stdout: nodeVersion } = await execa('node', ['-v'])
 
   await create({
     templateName: 'nvmrc',
-    output: '.nvmrc',
+    output: options.cwd ? `${options.cwd}/.nvmrc` : '.nvmrc',
     templateData: { nodeVersion },
   })
 }
@@ -113,12 +117,12 @@ export const config = async ({ javascript }: ConfigProps) => {
   }
 }
 
-export const husky = async () => {
-  await installPkg('husky')
-  await installPkg('pretty-quick')
+export const husky = async (options: ToolProps = {}) => {
+  await installPkg('husky', options)
+  await installPkg('pretty-quick', options)
 
   await create({
     templateName: 'huskyrc',
-    output: '.huskyrc',
+    output: options.cwd ? `${options.cwd}/.huskyrc` : '.huskyrc',
   })
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -100,11 +100,18 @@ export const hasPkg = async (packageName: string) => {
   )
 }
 
-export const installPkg = async (packageName: string) => {
+interface PackageOptions {
+  cwd?: string
+}
+
+export const installPkg = async (
+  packageName: string,
+  options: PackageOptions = {}
+) => {
   const hasPackageInstalled = await hasPkg(packageName)
 
   if (!hasPackageInstalled) {
     console.log(`Installing ${chalk.blue(packageName)}`)
-    await execa('npm', ['install', '--save-dev', packageName])
+    await execa.command(`npm install --save-dev ${packageName}`, options)
   }
 }

--- a/test/commands/graphql.spec.ts
+++ b/test/commands/graphql.spec.ts
@@ -1,0 +1,100 @@
+import { createFolder, create, overwrite } from '../../src/utils/file'
+import ora from 'ora'
+import { graphql } from '../../src/commands/graphql'
+import execa from 'execa'
+import { prettierrc, jest as jestFn, nvmrc, husky } from '../../src/tools'
+
+jest.mock('execa')
+jest.mock('../../src/utils/file')
+jest.mock('../../src/tools')
+
+jest.spyOn(global.console, 'log').mockImplementation(() => {})
+
+afterEach(jest.clearAllMocks)
+
+test('should setup a spinner', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(ora).toHaveBeenCalledWith({
+    text: 'Creating folder',
+    color: 'blue',
+  })
+})
+
+test('displays error if no name is provided', async () => {
+  await graphql({ flags: {} })
+
+  expect(createFolder).not.toHaveBeenCalled()
+})
+
+test('should create a project folder', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(createFolder).toHaveBeenCalledWith('test')
+})
+
+test('should setup git', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(execa.command).toHaveBeenCalledWith('git init', {
+    cwd: expect.stringMatching(/test/),
+  })
+
+  expect(overwrite).toHaveBeenCalledWith({
+    templateName: 'graphql/gitignore',
+    output: 'test/.gitignore',
+  })
+})
+
+test('should add package.json', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/package.json',
+    output: 'test/package.json',
+    templateData: {
+      name: 'test',
+    },
+  })
+})
+
+test('should install dependencies', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(execa.command).toHaveBeenCalledWith('npm install --silent', {
+    cwd: expect.stringMatching(/test/),
+  })
+})
+
+test('should use tools to create files', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(prettierrc).toHaveBeenCalledWith({ cwd: 'test' })
+  expect(jestFn).toHaveBeenCalledWith({ cwd: 'test' })
+  expect(nvmrc).toHaveBeenCalledWith({ cwd: 'test' })
+  expect(husky).toHaveBeenCalledWith({ cwd: 'test' })
+})
+
+test('should add tsconfig', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/tsconfig.json',
+    output: 'test/tsconfig.json',
+  })
+})
+
+test('should add lib folder', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(createFolder).toHaveBeenCalledWith('test/lib')
+})
+
+test('should add server', async () => {
+  await graphql({ name: 'test', flags: {} })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/server.ts',
+    output: 'test/lib/server.ts',
+  })
+})

--- a/test/commands/reason.spec.ts
+++ b/test/commands/reason.spec.ts
@@ -4,15 +4,6 @@ import ora from 'ora'
 import { create, overwrite, createFolder } from '../../src/utils/file'
 
 jest.mock('execa')
-jest.mock('chalk', () => ({
-  blue: (param: string) => param,
-  green: (param: string) => param,
-}))
-jest.mock('ora', () =>
-  jest.fn(({ text }) => ({
-    start: jest.fn().mockReturnValue({ text, stop: jest.fn() }),
-  }))
-)
 jest.mock('../../src/utils/file')
 
 jest.spyOn(global.console, 'log').mockImplementation(() => {})

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -4,6 +4,7 @@ import { react } from '../src/commands/react'
 import { reason } from '../src/commands/reason'
 import { add } from '../src/commands/add'
 import { snippets } from '../src/commands/snippets'
+import { graphql } from '../src/commands/graphql'
 
 jest.mock('chalk', () => ({
   blue: (param: string) => param,
@@ -19,6 +20,7 @@ jest.mock('../src/commands/react')
 jest.mock('../src/commands/reason')
 jest.mock('../src/commands/add')
 jest.mock('../src/commands/snippets')
+jest.mock('../src/commands/graphql')
 
 jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
@@ -62,6 +64,12 @@ test('handles snippet command', () => {
   run({ input: ['snippets'], flags: { language: 'typescript', ide: 'vim' } })
 
   expect(snippets).toHaveBeenCalledWith({ language: 'typescript', ide: 'vim' })
+})
+
+test('handles graphql command', () => {
+  run({ input: ['graphql', 'test'], flags: {} })
+
+  expect(graphql).toHaveBeenCalledWith({ name: 'test', flags: {} })
 })
 
 test('handles unknown command by displaying help', () => {

--- a/test/tools/index.spec.ts
+++ b/test/tools/index.spec.ts
@@ -34,7 +34,7 @@ describe('#prettierrc', () => {
   test('installs prettier', async () => {
     await prettierrc()
 
-    expect(installPkg).toHaveBeenCalledWith('prettier')
+    expect(installPkg).toHaveBeenCalledWith('prettier', {})
   })
 
   test('creates a prettier config', async () => {
@@ -45,19 +45,30 @@ describe('#prettierrc', () => {
       output: '.prettierrc',
     })
   })
+
+  test('creates a prettier config in subfolder', async () => {
+    await prettierrc({ cwd: 'test' })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'prettierrc',
+      output: 'test/.prettierrc',
+    })
+  })
 })
 
 describe('#jest', () => {
   test('installs jest', async () => {
-    await jestFn()
+    await jestFn({ cwd: 'test' })
 
-    expect(installPkg).toHaveBeenCalledWith('jest')
+    expect(installPkg).toHaveBeenCalledWith('jest', { cwd: 'test' })
   })
 
   test('installs jest typeahead', async () => {
-    await jestFn()
+    await jestFn({ cwd: 'test' })
 
-    expect(installPkg).toHaveBeenCalledWith('jest-watch-typeahead')
+    expect(installPkg).toHaveBeenCalledWith('jest-watch-typeahead', {
+      cwd: 'test',
+    })
   })
 
   test('creates a jest config', async () => {
@@ -66,6 +77,15 @@ describe('#jest', () => {
     expect(create).toHaveBeenCalledWith({
       templateName: 'jest.config',
       output: 'jest.config.js',
+    })
+  })
+
+  test('creates a jest config in subfolder', async () => {
+    await jestFn({ cwd: 'test' })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'jest.config',
+      output: 'test/jest.config.js',
     })
   })
 })
@@ -91,6 +111,22 @@ describe('#nvmrc', () => {
     expect(create).toHaveBeenCalledWith({
       templateName: 'nvmrc',
       output: '.nvmrc',
+      templateData: {
+        nodeVersion: 'v4.2.0',
+      },
+    })
+  })
+
+  test('creates a nvmrc with current node version in sub folder', async () => {
+    ;((execa as unknown) as jest.Mock).mockResolvedValue({
+      stdout: 'v4.2.0',
+    })
+
+    await nvmrc({ cwd: 'test' })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'nvmrc',
+      output: 'test/.nvmrc',
       templateData: {
         nodeVersion: 'v4.2.0',
       },
@@ -267,15 +303,15 @@ describe('#config', () => {
 
 describe('#husky', () => {
   test('installs husky', async () => {
-    await husky()
+    await husky({ cwd: 'test' })
 
-    expect(installPkg).toHaveBeenCalledWith('husky')
+    expect(installPkg).toHaveBeenCalledWith('husky', { cwd: 'test' })
   })
 
   test('installs pretty-quick', async () => {
-    await husky()
+    await husky({ cwd: 'test' })
 
-    expect(installPkg).toHaveBeenCalledWith('pretty-quick')
+    expect(installPkg).toHaveBeenCalledWith('pretty-quick', { cwd: 'test' })
   })
 
   test('creates a config', async () => {
@@ -284,6 +320,14 @@ describe('#husky', () => {
     expect(create).toHaveBeenCalledWith({
       templateName: 'huskyrc',
       output: '.huskyrc',
+    })
+  })
+  test('creates a config in a sub folder', async () => {
+    await husky({ cwd: 'test' })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'huskyrc',
+      output: 'test/.huskyrc',
     })
   })
 })

--- a/test/utils/file.spec.ts
+++ b/test/utils/file.spec.ts
@@ -256,10 +256,13 @@ describe('#installPkg', () => {
   test('installs package if it does not already exist', async () => {
     readPkgUp.mockReturnValue(undefined)
 
-    await installPkg('test')
+    await installPkg('jest')
 
-    expect(global.console.log).toHaveBeenCalledWith('Installing test')
-    expect(execa).toHaveBeenCalledWith('npm', ['install', '--save-dev', 'test'])
+    expect(global.console.log).toHaveBeenCalledWith('Installing jest')
+    expect(execa.command).toHaveBeenCalledWith(
+      'npm install --save-dev jest',
+      {}
+    )
   })
 
   test('does nothing if package is installed', async () => {
@@ -273,11 +276,21 @@ describe('#installPkg', () => {
 
     await installPkg('jest')
 
-    expect(global.console.log).not.toHaveBeenCalledWith('Installing test')
-    expect(execa).not.toHaveBeenCalledWith('npm', [
-      'install',
-      '--save-dev',
-      'test',
-    ])
+    expect(global.console.log).not.toHaveBeenCalledWith('Installing jest')
+    expect(execa.command).not.toHaveBeenCalledWith(
+      'npm install --save-dev jest',
+      {}
+    )
+  })
+
+  test('handles sub folders', async () => {
+    readPkgUp.mockReturnValue(undefined)
+
+    await installPkg('jest', { cwd: 'test' })
+
+    expect(global.console.log).toHaveBeenCalledWith('Installing jest')
+    expect(execa.command).toHaveBeenCalledWith('npm install --save-dev jest', {
+      cwd: expect.stringMatching(/test/),
+    })
   })
 })


### PR DESCRIPTION
Closes #43 

Adds a command to generate a simple GraphQL API.

`supreme graphql <folder-name>`