### PR TITLE
feat(graphql): add example generation

### DIFF
--- a/src/commands/graphql.ts
+++ b/src/commands/graphql.ts
@@ -10,7 +10,7 @@ interface GraphQLProps {
   name?: string
 }
 
-export const graphql = async ({ name }: GraphQLProps) => {
+export const graphql = async ({ name, flags }: GraphQLProps) => {
   if (!name) {
     console.log(`No name provided`)
     return
@@ -55,10 +55,29 @@ export const graphql = async ({ name }: GraphQLProps) => {
 
   await createFolder(`${name}/lib`)
 
-  await create({
-    templateName: 'graphql/server.ts',
-    output: `${name}/lib/server.ts`,
-  })
+  if (flags.examples) {
+    await create({
+      templateName: 'graphql/serverExample.ts',
+      output: `${name}/lib/server.ts`,
+    })
+
+    await createFolder(`${name}/lib/resolvers`)
+    await create({
+      templateName: 'graphql/resolversExample.ts',
+      output: `${name}/lib/resolvers/queue.ts`,
+    })
+
+    await createFolder(`${name}/lib/__generated__`)
+    await create({
+      templateName: 'graphql/graphql.d.ts',
+      output: `${name}/lib/__generated__/graphql.d.ts`,
+    })
+  } else {
+    await create({
+      templateName: 'graphql/server.ts',
+      output: `${name}/lib/server.ts`,
+    })
+  }
 
   spinner.stop()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export interface CLIFlags {
   javascript: boolean
   ide?: string
   language?: string
+  examples?: boolean
 }
 
 export interface CLIProps {
@@ -68,6 +69,7 @@ const cli = meow(
     --javascript    JavaScript app (react)
     --ide           IDE for snippets (snippets) 
     --language      Language for snippets (snippets) 
+    --examples      GraphQL examples (examples)
     `,
   {
     flags: {
@@ -80,6 +82,9 @@ const cli = meow(
       },
       language: {
         type: 'string',
+      },
+      examples: {
+        type: 'boolean',
       },
     },
   }

--- a/src/templates/graphql/graphql.d.ts.ejs
+++ b/src/templates/graphql/graphql.d.ts.ejs
@@ -1,0 +1,206 @@
+  import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+export type Maybe<T> = T | null;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+  /** The `Upload` scalar type represents a file upload. */
+  Upload: any,
+};
+
+
+export enum CacheControlScope {
+  Public = 'PUBLIC',
+  Private = 'PRIVATE'
+}
+
+export type Mutation = {
+   __typename?: 'Mutation',
+  _empty?: Maybe<Scalars['String']>,
+  addTrack: Array<Track>,
+};
+
+
+export type MutationAddTrackArgs = {
+  input: TrackInput
+};
+
+export type Query = {
+   __typename?: 'Query',
+  _empty?: Maybe<Scalars['String']>,
+  currentQueue: Array<Track>,
+};
+
+export type Subscription = {
+   __typename?: 'Subscription',
+  _empty?: Maybe<Scalars['String']>,
+  trackAdded: Track,
+};
+
+export type Track = {
+   __typename?: 'Track',
+  title: Scalars['String'],
+  artist: Scalars['String'],
+  album: Scalars['String'],
+};
+
+export type TrackInput = {
+  title: Scalars['String'],
+  artist: Scalars['String'],
+  album: Scalars['String'],
+};
+
+
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: ResolverTypeWrapper<{}>,
+  String: ResolverTypeWrapper<Scalars['String']>,
+  Track: ResolverTypeWrapper<Track>,
+  Mutation: ResolverTypeWrapper<{}>,
+  TrackInput: TrackInput,
+  Subscription: ResolverTypeWrapper<{}>,
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+  CacheControlScope: CacheControlScope,
+  Upload: ResolverTypeWrapper<Scalars['Upload']>,
+  Int: ResolverTypeWrapper<Scalars['Int']>,
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Query: {},
+  String: Scalars['String'],
+  Track: Track,
+  Mutation: {},
+  TrackInput: TrackInput,
+  Subscription: {},
+  Boolean: Scalars['Boolean'],
+  CacheControlScope: CacheControlScope,
+  Upload: Scalars['Upload'],
+  Int: Scalars['Int'],
+};
+
+export type CacheControlDirectiveResolver<Result, Parent, ContextType = any, Args = {   maxAge?: Maybe<Maybe<Scalars['Int']>>,
+  scope?: Maybe<Maybe<CacheControlScope>> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  addTrack?: Resolver<Array<ResolversTypes['Track']>, ParentType, ContextType, RequireFields<MutationAddTrackArgs, 'input'>>,
+};
+
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  currentQueue?: Resolver<Array<ResolversTypes['Track']>, ParentType, ContextType>,
+};
+
+export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+  _empty?: SubscriptionResolver<Maybe<ResolversTypes['String']>, "_empty", ParentType, ContextType>,
+  trackAdded?: SubscriptionResolver<ResolversTypes['Track'], "trackAdded", ParentType, ContextType>,
+};
+
+export type TrackResolvers<ContextType = any, ParentType extends ResolversParentTypes['Track'] = ResolversParentTypes['Track']> = {
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  artist?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  album?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+};
+
+export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload'
+}
+
+export type Resolvers<ContextType = any> = {
+  Mutation?: MutationResolvers<ContextType>,
+  Query?: QueryResolvers<ContextType>,
+  Subscription?: SubscriptionResolvers<ContextType>,
+  Track?: TrackResolvers<ContextType>,
+  Upload?: GraphQLScalarType,
+};
+
+
+/**
+ * @deprecated
+ * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+*/
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+export type DirectiveResolvers<ContextType = any> = {
+  cacheControl?: CacheControlDirectiveResolver<any, any, ContextType>,
+};
+
+
+/**
+* @deprecated
+* Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
+*/
+export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;
+

--- a/src/templates/graphql/package.json.ejs
+++ b/src/templates/graphql/package.json.ejs
@@ -14,9 +14,14 @@
   "license": "MIT",
   "dependencies": {
     "apollo-server-express": "2.9.4",
-    "express": "4.17.1"
+    "express": "4.17.1",
+    "lodash.merge": "4.6.2"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "1.7.0",
+    "@graphql-codegen/typescript": "1.7.0",
+    "@graphql-codegen/typescript-resolvers": "1.7.0",
+    "@types/lodash.merge": "4.6.6",
     "ts-node-dev": "1.0.0-pre.43",
     "typescript": "3.6.3"
   }

--- a/src/templates/graphql/resolversExample.ts.ejs
+++ b/src/templates/graphql/resolversExample.ts.ejs
@@ -1,0 +1,63 @@
+import { gql } from 'apollo-server-express'
+import { queue, pubsub } from '../server'
+import {
+  QueryResolvers,
+  MutationResolvers,
+  SubscriptionResolvers,
+} from '../__generated__/graphql'
+
+const TRACK_ADDED = 'TRACK_ADDED'
+
+export const typeDefs = gql`
+  type Track {
+    title: String!
+    artist: String!
+    album: String!
+  }
+
+  input TrackInput {
+    title: String!
+    artist: String!
+    album: String!
+  }
+
+  extend type Query {
+    currentQueue: [Track!]!
+  }
+
+  extend type Mutation {
+    addTrack(input: TrackInput!): [Track!]!
+  }
+
+  extend type Subscription {
+    trackAdded: Track!
+  }
+`
+
+interface Resolvers {
+  Query: QueryResolvers
+  Mutation: MutationResolvers
+  Subscription: SubscriptionResolvers
+}
+
+export const resolvers: Resolvers = {
+  Query: {
+    currentQueue: () => queue,
+  },
+
+  Mutation: {
+    addTrack: (_, { input }) => {
+      pubsub.publish(TRACK_ADDED, { trackAdded: input })
+      queue.push(input)
+
+      return queue
+    },
+  },
+
+  Subscription: {
+    trackAdded: {
+      subscribe: () => pubsub.asyncIterator([TRACK_ADDED]),
+    },
+  },
+}
+

--- a/src/templates/graphql/serverExample.ts.ejs
+++ b/src/templates/graphql/serverExample.ts.ejs
@@ -1,0 +1,98 @@
+import express from 'express'
+import { ApolloServer, gql, PubSub } from 'apollo-server-express'
+import {
+  typeDefs as queueDefs,
+  resolvers as queueResolvers,
+} from './resolvers/queue'
+import merge from 'lodash.merge'
+import { Track } from './__generated__/graphql'
+import http from 'http'
+
+export const pubsub = new PubSub()
+
+export const queue: Track[] = [
+  {
+    title: 'Hospital for Souls',
+    artist: 'Bring Me The Horizon',
+    album: 'Sempiternal',
+  },
+]
+
+const typeDefs = gql`
+  type Query {
+    _empty: String
+  }
+
+  type Mutation {
+    _empty: String
+  }
+
+  type Subscription {
+    _empty: String
+  }
+`
+
+const server = new ApolloServer({
+  typeDefs: [typeDefs, queueDefs],
+  resolvers: merge(queueResolvers),
+  playground: {
+    tabs: [
+      {
+        endpoint: 'http://localhost:4000/graphql',
+        name: 'Queries',
+        query: `query currentQueue {
+  currentQueue {
+    ...TrackInfo
+  }
+}
+
+# Might need to prettify for Playground to see this mutation<Paste>
+mutation addTrack($track: TrackInput!) {
+  addTrack(input: $track) {
+    ...TrackInfo
+  }
+}
+
+fragment TrackInfo on Track {
+  title
+  artist
+  album
+}
+        `,
+        variables: `{
+  "track": {
+    "title": "Antivist",
+    "album": "Sempiternal",
+    "artist": "Bring Me The Horizon"
+  }
+}`,
+      },
+      {
+        endpoint: 'http://localhost:4000/graphql',
+        name: 'Subscription',
+        query: `# Run this subscription query then run the mutation in the first tab
+# to see the results to the right
+subscription trackAdded {
+  trackAdded {
+    title
+    artist
+    album
+  }
+}`,
+      },
+    ],
+  },
+})
+
+const app = express()
+
+server.applyMiddleware({ app })
+
+const httpServer = http.createServer(app)
+server.installSubscriptionHandlers(httpServer)
+
+httpServer.listen({ port: 4000 }, () =>
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+)
+
+

--- a/test/commands/graphql.spec.ts
+++ b/test/commands/graphql.spec.ts
@@ -98,3 +98,32 @@ test('should add server', async () => {
     output: 'test/lib/server.ts',
   })
 })
+
+test('should add server with examples', async () => {
+  await graphql({ name: 'test', flags: { examples: true } })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/serverExample.ts',
+    output: 'test/lib/server.ts',
+  })
+})
+
+test('should add resolvers with examples', async () => {
+  await graphql({ name: 'test', flags: { examples: true } })
+
+  expect(createFolder).toHaveBeenCalledWith('test/lib/resolvers')
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/resolversExample.ts',
+    output: 'test/lib/resolvers/queue.ts',
+  })
+})
+
+test('should add generated types', async () => {
+  await graphql({ name: 'test', flags: { examples: true } })
+
+  expect(createFolder).toHaveBeenCalledWith('test/lib/__generated__')
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'graphql/graphql.d.ts',
+    output: 'test/lib/__generated__/graphql.d.ts',
+  })
+})


### PR DESCRIPTION
Closes #47 

Add optional `--examples` flag for GraphQL which generates a query, a mutation and a subscription on some local state. Examples queries are displayed in Playground.