### PR TITLE
feat: add github actions generation

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -2,7 +2,7 @@ name: Run tests on PR
 
 on:
   pull_request:
-    branches: 
+    branches:
       - master
 
 jobs:
@@ -17,15 +17,16 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: npm install, build, and test
-      run: |
-        npm ci
-        npm test
-      env:
-        CI: true
+      - name: npm install, build, and test
+        run: |
+          npm ci
+          npm run lint --if-present
+          npm test
+        env:
+          CI: true

--- a/src/commands/ghactions.ts
+++ b/src/commands/ghactions.ts
@@ -1,0 +1,20 @@
+import { create, createFolder, folderExists } from '../utils/file'
+
+export const ghactions = async () => {
+  const workflowsFolder = await folderExists('.github')
+
+  if (!workflowsFolder.isDirectory()) {
+    await createFolder('.github')
+    await createFolder('.github/workflows')
+  }
+
+  await create({
+    templateName: 'ghactions/pr_check.yml',
+    output: '.github/workflows/pr_check.yml',
+  })
+
+  await create({
+    templateName: 'ghactions/release.yml',
+    output: '.github/workflows/release.yml',
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { reason } from './commands/reason'
 import { init } from './commands/init'
 import { snippets, SnippetLanguage, SnippetIDE } from './commands/snippets'
 import { graphql } from './commands/graphql'
+import { ghactions } from './commands/ghactions'
 
 export interface CLIFlags {
   examples?: boolean
@@ -49,6 +50,9 @@ export const run = (cli: meow.Result) => {
     case 'graphql':
       graphql({ name, flags: flags as CLIFlags })
       break
+    case 'ghactions':
+      ghactions()
+      break
     default:
       console.log(help)
   }
@@ -66,6 +70,7 @@ const cli = meow(
     $ reason <name>             Creates a ReasonReact app
     $ snippets [flags]          Copy snippets to clipboard
     $ graphql <name>            Create a GraphQL API
+    $ ghactions                 Create base GitHub actions
 
     Flags
     --javascript    JavaScript app (react)

--- a/src/templates/ghactions/pr_check.yml.ejs
+++ b/src/templates/ghactions/pr_check.yml.ejs
@@ -1,0 +1,32 @@
+name: Run tests on PR
+
+on:
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  test:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Run tests and linting
+      run: |
+        npm ci
+        npm run lint --if-present
+        npm test
+      env:
+        CI: true

--- a/src/templates/ghactions/release.yml.ejs
+++ b/src/templates/ghactions/release.yml.ejs
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest 
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+
+    - name: Run tests and linting
+      run: |
+        npm install
+        npm run lint --if-present
+        npm test
+      env:
+        CI: true
+
+    - name: Create release using semantic-release
+      run: npx semantic-release
+      env:
+        # GITHUB_TOKEN is added automatically by GitHub
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        CI: true

--- a/test/commands/ghactions.spec.ts
+++ b/test/commands/ghactions.spec.ts
@@ -1,0 +1,48 @@
+import { ghactions } from '../../src/commands/ghactions'
+import { create, createFolder, folderExists } from '../../src/utils/file'
+
+jest.mock('../../src/utils/file')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(folderExists as jest.Mock).mockResolvedValueOnce({
+    isDirectory: jest.fn().mockReturnValue(false),
+  })
+})
+
+test('should create workflows folders', async () => {
+  await ghactions()
+
+  expect(folderExists).toHaveBeenCalledWith('.github')
+  expect(createFolder).toHaveBeenCalledWith('.github')
+  expect(createFolder).toHaveBeenCalledWith('.github/workflows')
+})
+
+test('should not create folders if they exist', async () => {
+  ;(folderExists as jest.Mock).mockReset()
+  ;(folderExists as jest.Mock).mockResolvedValueOnce({
+    isDirectory: jest.fn().mockReturnValue(true),
+  })
+
+  await ghactions()
+
+  expect(createFolder).not.toHaveBeenCalled()
+})
+
+test('should create a PR check action', async () => {
+  await ghactions()
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'ghactions/pr_check.yml',
+    output: '.github/workflows/pr_check.yml',
+  })
+})
+
+test('should create a release action', async () => {
+  await ghactions()
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'ghactions/release.yml',
+    output: '.github/workflows/release.yml',
+  })
+})

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,6 +5,7 @@ import { reason } from '../src/commands/reason'
 import { add } from '../src/commands/add'
 import { snippets } from '../src/commands/snippets'
 import { graphql } from '../src/commands/graphql'
+import { ghactions } from '../src/commands/ghactions'
 
 jest.mock('chalk', () => ({
   blue: (param: string) => param,
@@ -21,6 +22,7 @@ jest.mock('../src/commands/reason')
 jest.mock('../src/commands/add')
 jest.mock('../src/commands/snippets')
 jest.mock('../src/commands/graphql')
+jest.mock('../src/commands/ghactions')
 
 jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
@@ -70,6 +72,12 @@ test('handles graphql command', () => {
   run({ input: ['graphql', 'test'], flags: {} })
 
   expect(graphql).toHaveBeenCalledWith({ name: 'test', flags: {} })
+})
+
+test('handles github actions command', () => {
+  run({ input: ['ghactions'], flags: {} })
+
+  expect(ghactions).toHaveBeenCalled()
 })
 
 test('handles unknown command by displaying help', () => {

--- a/test/tools/index.spec.ts
+++ b/test/tools/index.spec.ts
@@ -341,6 +341,12 @@ describe('#eslint', () => {
     expect(installPkg).toHaveBeenCalledWith('eslint', { cwd: 'test' })
   })
 
+  test('install eslint without cwd', async () => {
+    await eslint()
+
+    expect(installPkg).toHaveBeenCalledWith('eslint', {})
+  })
+
   describe('Node', () => {
     test('installs eslint node config', async () => {
       await eslint({ cwd: 'test', node: true })


### PR DESCRIPTION
Closes #63 

Generate two files for GitHub actions, one that runs tests and linting on pull requests targeting the master branch and one that runs tests and publishes a new release on push to the master branch. 