### PR TITLE
fix: use spinner for install package when available

### DIFF
--- a/src/commands/graphql.ts
+++ b/src/commands/graphql.ts
@@ -41,11 +41,11 @@ export const graphql = async ({ name, flags }: GraphQLProps) => {
   })
   await execa.command('npm install --silent', projectFolder)
 
-  await prettierrc({ cwd: name })
-  await jest({ cwd: name })
-  await nvmrc({ cwd: name })
-  await husky({ cwd: name })
-  await eslint({ cwd: name, node: true })
+  await prettierrc({ cwd: name, spinner })
+  await jest({ cwd: name, spinner })
+  await nvmrc({ cwd: name, spinner })
+  await husky({ cwd: name, spinner })
+  await eslint({ cwd: name, node: true, spinner })
 
   spinner.text = 'Creating base files'
 

--- a/src/commands/typescript.ts
+++ b/src/commands/typescript.ts
@@ -34,12 +34,12 @@ export const typescript = async ({ name }: TypescriptProps) => {
 
   await execa.command('npm install --silent', projectFolder)
 
-  await prettierrc({ cwd: name })
-  await jest({ cwd: name })
-  await nvmrc({ cwd: name })
-  await husky({ cwd: name })
-  await gitignore({ cwd: name })
-  await eslint({ cwd: name, node: true })
+  await prettierrc({ cwd: name, spinner })
+  await jest({ cwd: name, spinner })
+  await nvmrc({ cwd: name, spinner })
+  await husky({ cwd: name, spinner })
+  await gitignore({ cwd: name, spinner })
+  await eslint({ cwd: name, node: true, spinner })
 
   spinner.text = 'Creating files'
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,10 @@
 import { create, createFolder, folderExists, installPkg } from '../utils/file'
 import execa from 'execa'
+import { Ora } from 'ora'
 
 interface ToolProps {
   cwd?: string
+  spinner?: Ora
 }
 
 export const gitignore = async (options: ToolProps = {}) => {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -6,6 +6,7 @@ import util from 'util'
 import ejs from 'ejs'
 import readPkgUp from 'read-pkg-up'
 import inquirer from 'inquirer'
+import { Ora } from 'ora'
 
 interface HandleFileData {
   templateName: string
@@ -90,6 +91,7 @@ export const folderExists = (folderName: string) => {
 
 interface PackageOptions {
   cwd?: string
+  spinner?: Ora
 }
 
 export const hasPkg = async (packageName: string, options: PackageOptions) => {
@@ -115,7 +117,14 @@ export const installPkg = async (
   const hasPackageInstalled = await hasPkg(packageName, options)
 
   if (!hasPackageInstalled) {
-    console.log(`Installing ${chalk.blue(packageName)}`)
+    const msg = `Installing ${chalk.blue(packageName)}`
+
+    if (options.spinner) {
+      options.spinner.text = msg
+    } else {
+      console.log(msg)
+    }
+
     await execa.command(
       `npm install --save-dev --save-exact ${packageName}`,
       options

--- a/test/commands/graphql.spec.ts
+++ b/test/commands/graphql.spec.ts
@@ -75,11 +75,27 @@ test('should install dependencies', async () => {
 test('should use tools to create files', async () => {
   await graphql({ name: 'test', flags: {} })
 
-  expect(prettierrc).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(jestFn).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(nvmrc).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(husky).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(eslint).toHaveBeenCalledWith({ cwd: 'test', node: true })
+  expect(prettierrc).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(jestFn).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(nvmrc).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(husky).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(eslint).toHaveBeenCalledWith({
+    cwd: 'test',
+    node: true,
+    spinner: expect.any(Object),
+  })
 })
 
 test('should add tsconfig', async () => {

--- a/test/commands/typescript.spec.ts
+++ b/test/commands/typescript.spec.ts
@@ -53,12 +53,31 @@ test('should install dependencies', async () => {
 test('should use tools to create files', async () => {
   await typescript({ name: 'test', flags: {} })
 
-  expect(prettierrc).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(jestFn).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(nvmrc).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(husky).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(gitignore).toHaveBeenCalledWith({ cwd: 'test' })
-  expect(eslint).toHaveBeenCalledWith({ cwd: 'test', node: true })
+  expect(prettierrc).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(jestFn).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(nvmrc).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(husky).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(gitignore).toHaveBeenCalledWith({
+    cwd: 'test',
+    spinner: expect.any(Object),
+  })
+  expect(eslint).toHaveBeenCalledWith({
+    cwd: 'test',
+    node: true,
+    spinner: expect.any(Object),
+  })
 })
 
 test('creates lib folder', async () => {

--- a/test/utils/file.spec.ts
+++ b/test/utils/file.spec.ts
@@ -289,6 +289,17 @@ describe('#installPkg', () => {
     )
   })
 
+  test('uses spinner for text if it exists', async () => {
+    readPkgUp.mockReturnValue(undefined)
+
+    const spinner = {}
+
+    await installPkg('jest', { spinner })
+
+    expect(global.console.log).not.toHaveBeenCalled()
+    expect(spinner.text).toEqual('Installing jest')
+  })
+
   test('handles sub folders', async () => {
     readPkgUp.mockReturnValue(undefined)
 


### PR DESCRIPTION
Fixes #72 

Use spinner from `ora` when we have one to display the message that a package is being installed.