### PR TITLE
feat: add github actions without npm release

### DIFF
--- a/src/commands/ghactions.ts
+++ b/src/commands/ghactions.ts
@@ -41,6 +41,9 @@ export const ghactions = async ({ flags }: GhActionsProps) => {
   await create({
     templateName: 'ghactions/release.yml',
     output: '.github/workflows/release.yml',
+    templateData: {
+      npm: flags.npm,
+    },
   })
 
   console.log(`Added GitHub actions in ${chalk.green(`.github/workflows`)}`)

--- a/src/commands/ghactions.ts
+++ b/src/commands/ghactions.ts
@@ -1,7 +1,12 @@
 import { create, createFolder, folderExists, installPkg } from '../utils/file'
 import chalk from 'chalk'
+import { CLIFlags } from '../'
 
-export const ghactions = async () => {
+interface GhActionsProps {
+  flags: CLIFlags
+}
+
+export const ghactions = async ({ flags }: GhActionsProps) => {
   const githubFolder = folderExists('.github')
   const workflowsFolder = folderExists('.github/workflows')
 
@@ -16,10 +21,17 @@ export const ghactions = async () => {
     await createFolder('.github/workflows')
   }
 
-  await create({
-    templateName: 'ghactions/releaserc',
-    output: '.releaserc',
-  })
+  if (flags.npm) {
+    await create({
+      templateName: 'ghactions/releaserc',
+      output: '.releaserc',
+    })
+  } else {
+    await create({
+      templateName: 'ghactions/releaserc.nonpm',
+      output: '.releaserc',
+    })
+  }
 
   await create({
     templateName: 'ghactions/pr_check.yml',

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export interface CLIFlags {
   language?: string
   node?: boolean
   react?: boolean
+  npm?: boolean
 }
 
 export interface CLIProps {
@@ -52,7 +53,7 @@ export const run = (cli: any) => {
       graphql({ name, flags: flags as CLIFlags })
       break
     case 'ghactions':
-      ghactions()
+      ghactions({ flags: flags as CLIFlags })
       break
     case 'typescript':
       typescript({ name, flags: flags as CLIFlags })
@@ -84,6 +85,7 @@ const cli = meow(
     --examples      GraphQL examples (examples)
     --node          ESLint node (add/init)
     --react         ESLint react (add/init)
+    --no-npm        Remove npm release (ghactions)    
     `,
   {
     flags: {
@@ -105,6 +107,10 @@ const cli = meow(
       },
       node: {
         type: 'boolean',
+      },
+      npm: {
+        type: 'boolean',
+        default: true,
       },
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface CLIFlags {
   language?: string
   node?: boolean
   react?: boolean
-  npm?: boolean
+  npm: boolean
 }
 
 export interface CLIProps {

--- a/src/templates/ghactions/release.yml.ejs
+++ b/src/templates/ghactions/release.yml.ejs
@@ -27,5 +27,4 @@ jobs:
       env:
         # GITHUB_TOKEN is added automatically by GitHub
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        CI: true
+        <% if (npm) { %>NPM_TOKEN: ${{ secrets.NPM_TOKEN }}<% } %>

--- a/src/templates/ghactions/releaserc.nonpm.ejs
+++ b/src/templates/ghactions/releaserc.nonpm.ejs
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    "@semantic-release/git"
+  ]
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -11,7 +11,7 @@ import { Ora } from 'ora'
 interface HandleFileData {
   templateName: string
   output: string
-  templateData?: { [key: string]: string }
+  templateData?: { [key: string]: string | boolean }
 }
 
 interface HandleFileOptions {

--- a/test/commands/ghactions.spec.ts
+++ b/test/commands/ghactions.spec.ts
@@ -9,7 +9,13 @@ import {
 jest.mock('../../src/utils/file')
 jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
+let flags
+
 beforeEach(() => {
+  flags = {
+    npm: true,
+  }
+
   jest.clearAllMocks()
   ;(folderExists as jest.Mock)
     .mockReturnValueOnce(false)
@@ -17,14 +23,14 @@ beforeEach(() => {
 })
 
 test('should install dependencies', async () => {
-  await ghactions()
+  await ghactions({ flags })
 
   expect(installPkg).toHaveBeenCalledWith('@semantic-release/changelog')
   expect(installPkg).toHaveBeenCalledWith('@semantic-release/git')
 })
 
 test('should create workflows folders', async () => {
-  await ghactions()
+  await ghactions({ flags })
 
   expect(folderExists).toHaveBeenCalledWith('.github')
   expect(folderExists).toHaveBeenCalledWith('.github/workflows')
@@ -39,13 +45,13 @@ test('should not create folders if they exist', async () => {
     .mockReturnValueOnce(true)
     .mockReturnValueOnce(true)
 
-  await ghactions()
+  await ghactions({ flags })
 
   expect(createFolder).not.toHaveBeenCalled()
 })
 
-test('should create a .releaserc', async () => {
-  await ghactions()
+test('should create a .releaserc if npm flag is true', async () => {
+  await ghactions({ flags })
 
   expect(create).toHaveBeenCalledWith({
     templateName: 'ghactions/releaserc',
@@ -53,8 +59,19 @@ test('should create a .releaserc', async () => {
   })
 })
 
+test('should create a .releaserc without npm release if npm flag is false', async () => {
+  flags.npm = false
+
+  await ghactions({ flags })
+
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'ghactions/releaserc.nonpm',
+    output: '.releaserc',
+  })
+})
+
 test('should create a PR check action', async () => {
-  await ghactions()
+  await ghactions({ flags })
 
   expect(create).toHaveBeenCalledWith({
     templateName: 'ghactions/pr_check.yml',
@@ -63,7 +80,7 @@ test('should create a PR check action', async () => {
 })
 
 test('should create a release action', async () => {
-  await ghactions()
+  await ghactions({ flags })
 
   expect(create).toHaveBeenCalledWith({
     templateName: 'ghactions/release.yml',
@@ -72,7 +89,7 @@ test('should create a release action', async () => {
 })
 
 test('should display a message', async () => {
-  await ghactions()
+  await ghactions({ flags })
 
   expect(global.console.log).toHaveBeenCalledWith(
     'Added GitHub actions in .github/workflows'

--- a/test/commands/ghactions.spec.ts
+++ b/test/commands/ghactions.spec.ts
@@ -85,6 +85,9 @@ test('should create a release action', async () => {
   expect(create).toHaveBeenCalledWith({
     templateName: 'ghactions/release.yml',
     output: '.github/workflows/release.yml',
+    templateData: {
+      npm: true,
+    },
   })
 })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -79,7 +79,7 @@ test('handles graphql command', () => {
 test('handles github actions command', () => {
   run({ input: ['ghactions'], flags: {} })
 
-  expect(ghactions).toHaveBeenCalled()
+  expect(ghactions).toHaveBeenCalledWith({ flags: {} })
 })
 
 test('handles typescript command', () => {

--- a/test/utils/file.spec.ts
+++ b/test/utils/file.spec.ts
@@ -5,6 +5,7 @@ import {
   hasPkg,
   overwrite,
   installPkg,
+  readSnippet,
 } from '../../src/utils/file'
 import ejs from 'ejs'
 import util from 'util'
@@ -30,6 +31,16 @@ jest.spyOn(global.console, 'error').mockImplementation(() => {})
 
 beforeEach(() => {
   jest.clearAllMocks()
+})
+
+describe('#readSnippet', () => {
+  it('gets a specific snippet', () => {
+    readSnippet('test')
+
+    expect(ejs.renderFile).toHaveBeenCalledWith(
+      expect.stringContaining('test.ejs')
+    )
+  })
 })
 
 describe('#create', () => {


### PR DESCRIPTION
This PR adds the functionality to pass `--no-npm` to `ghactions` (GitHub actions). With the flag, `supreme` will:

- Generate a `.releaserc` where `@semantic-release/npm` is turned off
- Remove the `NPM_TOKEN` secret from the `release.yml`.