### PR TITLE
feat: graphql auth flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "contributors": [
     {
       "name": "Jimmy Jardland"
+    },
+    {
+      "name": "Andreas Lundqvist"
     }
   ],
   "repository": "github:Iteam1337/supreme",

--- a/src/commands/graphql.ts
+++ b/src/commands/graphql.ts
@@ -3,7 +3,7 @@ import execa from 'execa'
 import ora from 'ora'
 import path from 'path'
 import { husky, jest, nvmrc, prettierrc, eslint } from '../tools'
-import { create, createFolder, overwrite } from '../utils/file'
+import { create, createFolder, overwrite, installPkg } from '../utils/file'
 
 interface GraphQLProps {
   flags: any
@@ -49,15 +49,40 @@ export const graphql = async ({ name, flags }: GraphQLProps) => {
 
   spinner.text = 'Creating base files'
 
-  await create({
-    templateName: 'typescript/tsconfig.json',
-    output: `${name}/tsconfig.json`,
-  })
-
   await createFolder(`${name}/lib`)
   await createFolder(`${name}/lib/__generated__`)
 
-  if (flags.examples) {
+  if (flags.auth) {
+    spinner.text = 'Installing additional dependencies'
+
+    await installPkg('graphql-directive-auth@0.3.2', {
+      spinner,
+      cwd: name,
+      dev: false,
+    })
+    await installPkg('graphql-tools@6.0.10', { spinner, cwd: name, dev: false })
+
+    spinner.text = 'Creating base files'
+    await create({
+      templateName: 'graphql/auth/server.ts',
+      output: `${name}/lib/server.ts`,
+    })
+
+    await create({
+      templateName: 'graphql/auth/graphql.d.ts',
+      output: `${name}/lib/__generated__/graphql.d.ts`,
+    })
+
+    await create({
+      templateName: 'graphql/auth/index.d.ts',
+      output: `${name}/index.d.ts`,
+    })
+
+    await create({
+      templateName: 'graphql/auth/tsconfig.json',
+      output: `${name}/tsconfig.json`,
+    })
+  } else if (flags.examples) {
     await create({
       templateName: 'graphql/serverExample.ts',
       output: `${name}/lib/server.ts`,
@@ -82,6 +107,11 @@ export const graphql = async ({ name, flags }: GraphQLProps) => {
     await create({
       templateName: 'graphql/graphql.d.ts',
       output: `${name}/lib/__generated__/graphql.d.ts`,
+    })
+
+    await create({
+      templateName: 'typescript/tsconfig.json',
+      output: `${name}/tsconfig.json`,
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export interface CLIFlags {
   node?: boolean
   react?: boolean
   npm: boolean
+  auth?: boolean
 }
 
 export interface CLIProps {
@@ -74,7 +75,7 @@ const cli = meow(
     $ react <name> [flags]      Creates a React app (CRA)
     $ reason <name>             Creates a ReasonReact app
     $ snippets [flags]          Copy snippets to clipboard
-    $ graphql <name>            Create a GraphQL API
+    $ graphql <name> [flags]    Create a GraphQL API
     $ ghactions                 Create base GitHub actions
     $ typescript                Create basic Typescript app
 
@@ -86,6 +87,7 @@ const cli = meow(
     --node          ESLint node (add/init)
     --react         ESLint react (add/init)
     --no-npm        Remove npm release (ghactions)    
+    --auth          Directives for JWT authorization (graphql)
     `,
   {
     flags: {
@@ -112,6 +114,7 @@ const cli = meow(
         type: 'boolean',
         default: true,
       },
+      auth: { type: 'boolean' },
     },
   }
 )

--- a/src/templates/graphql/auth/graphql.d.ts.ejs
+++ b/src/templates/graphql/auth/graphql.d.ts.ejs
@@ -1,0 +1,192 @@
+import { GraphQLResolveInfo } from 'graphql'
+export type Maybe<T> = T | null
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string
+  String: string
+  Boolean: boolean
+  Int: number
+  Float: number
+}
+
+export type Person = {
+  __typename?: 'Person'
+  name: Scalars['String']
+  age: Scalars['Int']
+}
+
+export type Query = {
+  __typename?: 'Query'
+  person: Person
+}
+
+export type ResolverTypeWrapper<T> = Promise<T> | T
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult
+
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
+
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes>
+
+export type NextResolverFn<T> = () => Promise<T>
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: ResolverTypeWrapper<{}>
+  Person: ResolverTypeWrapper<Person>
+  String: ResolverTypeWrapper<Scalars['String']>
+  Int: ResolverTypeWrapper<Scalars['Int']>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
+}
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Query: {}
+  Person: Person
+  String: Scalars['String']
+  Int: Scalars['Int']
+  Boolean: Scalars['Boolean']
+}
+
+export type IsAuthenticatedDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = any,
+  Args = {}
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
+
+export type HasRoleDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = any,
+  Args = { role: Maybe<Maybe<Scalars['String']>> }
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
+
+export type PersonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person']
+> = {
+  name: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  age: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+}
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  person: Resolver<ResolversTypes['Person'], ParentType, ContextType>
+}
+
+export type Resolvers<ContextType = any> = {
+  Person: PersonResolvers<ContextType>
+  Query: QueryResolvers<ContextType>
+}
+
+/**
+ * @deprecated
+ * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+ */
+export type IResolvers<ContextType = any> = Resolvers<ContextType>
+export type DirectiveResolvers<ContextType = any> = {
+  isAuthenticated: IsAuthenticatedDirectiveResolver<any, any, ContextType>
+  hasRole: HasRoleDirectiveResolver<any, any, ContextType>
+}
+
+/**
+ * @deprecated
+ * Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
+ */
+export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<
+  ContextType
+>

--- a/src/templates/graphql/auth/index.d.ts.ejs
+++ b/src/templates/graphql/auth/index.d.ts.ejs
@@ -1,0 +1,8 @@
+declare type AuthContext = {
+  auth: {
+    id: string
+    fullName: string
+    iat: number
+    exp: number
+  }
+}

--- a/src/templates/graphql/auth/server.ts.ejs
+++ b/src/templates/graphql/auth/server.ts.ejs
@@ -1,0 +1,63 @@
+import express from 'express'
+import { ApolloServer, gql } from 'apollo-server-express'
+import { QueryResolvers } from './__generated__/graphql'
+import { makeExecutableSchema } from 'graphql-tools'
+import { AuthDirective } from 'graphql-directive-auth'
+
+/*
+ * AuthDirective uses the environment
+ * variable name 'APP_SECRET' to verify JWT.
+ */
+process.env.APP_SECRET = 'jwtKey' // move me!
+
+const typeDefs = gql`
+  """
+  Directives
+  """
+  directive @isAuthenticated on FIELD | FIELD_DEFINITION
+  directive @hasRole(role: String) on FIELD | FIELD_DEFINITION
+
+  type Person {
+    name: String!
+    age: Int!
+  }
+
+  type Query {
+    person: Person! @isAuthenticated
+  }
+`
+
+const person: QueryResolvers<AuthContext>['person'] = (
+  _,
+  __,
+  { auth } // Properties from parsed JWT as type AuthContext
+) => ({ name: auth.fullName, age: 30 })
+
+const resolvers = {
+  Query: {
+    person,
+  },
+}
+
+const schema = { typeDefs, resolvers }
+
+const executableSchema = makeExecutableSchema({
+  ...schema,
+  schemaDirectives: {
+    // to use @hasRole and @isAuthenticated directives
+    ...AuthDirective(),
+  },
+})
+
+const server = new ApolloServer({
+  schema: executableSchema,
+  context: ({ connection, req }) => (connection ? connection.context : { req }),
+})
+
+const app = express()
+
+server.applyMiddleware({ app })
+
+app.listen({ port: 4000 }, () =>
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+)

--- a/src/templates/graphql/auth/tsconfig.json.ejs
+++ b/src/templates/graphql/auth/tsconfig.json.ejs
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "build",
+    "rootDir": ".",
+    "sourceMap": true,
+    "target": "esnext",
+    "strict": true
+  },
+  "include": ["./lib/**/*"],
+  "files": ["index.d.ts"]
+}

--- a/src/templates/graphql/package.json.ejs
+++ b/src/templates/graphql/package.json.ejs
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "dev": "ts-node-dev --no-notify --ignore-watch node_modules lib/server.ts",
+    "dev": "ts-node-dev --no-notify --type-check --ignore-watch node_modules lib/server.ts",
     "generate": "graphql-codegen --config codegen.yml"
   },
   "keywords": ["graphql", "apollo"],
@@ -24,6 +24,6 @@
     "@graphql-codegen/typescript-resolvers": "1.8.1",
     "@types/lodash.merge": "4.6.6",
     "ts-node-dev": "1.0.0-pre.43",
-    "typescript": "3.6.4"
+    "typescript": "3.9.5"
   }
 }

--- a/src/templates/typescript/package.json.ejs
+++ b/src/templates/typescript/package.json.ejs
@@ -15,7 +15,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "typescript": "3.6.4"
+    "typescript": "3.9.5"
   }
 }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -92,6 +92,7 @@ export const folderExists = (folderName: string) => {
 interface PackageOptions {
   cwd?: string
   spinner?: Ora
+  dev?: boolean
 }
 
 export const hasPkg = async (packageName: string, options: PackageOptions) => {
@@ -126,7 +127,9 @@ export const installPkg = async (
     }
 
     await execa.command(
-      `npm install --save-dev --save-exact ${packageName}`,
+      `npm install ${
+        options.dev === false ? '' : '--save-dev'
+      } --save-exact ${packageName}`,
       options
     )
   }

--- a/test/commands/graphql.spec.ts
+++ b/test/commands/graphql.spec.ts
@@ -1,4 +1,9 @@
-import { createFolder, create, overwrite } from '../../src/utils/file'
+import {
+  createFolder,
+  create,
+  overwrite,
+  installPkg,
+} from '../../src/utils/file'
 import ora from 'ora'
 import { graphql } from '../../src/commands/graphql'
 import execa from 'execa'
@@ -167,5 +172,58 @@ test('should add codegen configuration', async () => {
   expect(create).toHaveBeenCalledWith({
     templateName: 'graphql/codegen.yml',
     output: 'test/codegen.yml',
+  })
+})
+
+describe('flags:auth', () => {
+  test('should install additional dependencies', async () => {
+    const name = 'test'
+    await graphql({ name, flags: { auth: true } })
+
+    expect(installPkg).toHaveBeenCalledWith(
+      'graphql-directive-auth@0.3.2',
+      expect.objectContaining({ cwd: name, dev: false })
+    )
+    expect(installPkg).toHaveBeenCalledWith(
+      'graphql-tools@6.0.10',
+      expect.objectContaining({ cwd: name, dev: false })
+    )
+  })
+
+  test('should add generated types', async () => {
+    await graphql({ name: 'test', flags: { auth: true } })
+
+    expect(createFolder).toHaveBeenCalledWith('test/lib/__generated__')
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'graphql/auth/graphql.d.ts',
+      output: 'test/lib/__generated__/graphql.d.ts',
+    })
+  })
+
+  test('should add server', async () => {
+    await graphql({ name: 'test', flags: { auth: true } })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'graphql/auth/server.ts',
+      output: 'test/lib/server.ts',
+    })
+  })
+
+  test('should add global type declaration file', async () => {
+    await graphql({ name: 'test', flags: { auth: true } })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'graphql/auth/index.d.ts',
+      output: 'test/index.d.ts',
+    })
+  })
+
+  test('should add tsconfig', async () => {
+    await graphql({ name: 'test', flags: { auth: true } })
+
+    expect(create).toHaveBeenCalledWith({
+      templateName: 'graphql/auth/tsconfig.json',
+      output: 'test/tsconfig.json',
+    })
   })
 })


### PR DESCRIPTION
This feature adds the ability to pass a `--auth` flag to the graphql command.

What this flag does:
- Adds additional dependencies `graphql-directive-auth` and `graphql-tools`
- Substitutes some other files in the boilerplate that are relevant for these changes

Why:
- Handling JWT authorization flows and role based strategy patterns for the API in a pretty smooth way

Additional changes:
- bump typescript version

More information:
https://github.com/graphql-community/graphql-directive-auth
 