### PR TITLE
feat: update reason setup

### DIFF
--- a/src/commands/reason.ts
+++ b/src/commands/reason.ts
@@ -63,8 +63,11 @@ export const reason = async ({ name }: CLIProps) => {
 
   // Setup Tailwind CSS
   spinner.text = 'Setting up styling'
-  await execa('npx', ['tailwind', 'init'], projectFolder)
 
+  await create({
+    templateName: 'reason/tailwind.config.js',
+    output: `${projectName}/tailwind.config.js`,
+  })
   await create({
     templateName: 'reason/postcss.config.js',
     output: `${projectName}/postcss.config.js`,

--- a/src/templates/reason/App_test.re.ejs
+++ b/src/templates/reason/App_test.re.ejs
@@ -1,5 +1,4 @@
 open Jest;
-open Expect;
 open ReactTestingLibrary;
 open JestDom;
 

--- a/src/templates/reason/bsconfig.json.ejs
+++ b/src/templates/reason/bsconfig.json.ejs
@@ -15,7 +15,8 @@
   ],
   "package-specs": [
     {
-      "module": "commonjs"
+      "module": "commonjs",
+      "in-source": true
     }
   ],
   "suffix": ".bs.js",

--- a/src/templates/reason/gitignore.ejs
+++ b/src/templates/reason/gitignore.ejs
@@ -3,12 +3,8 @@
 
 # Build folders
 /lib/bs
-## CommonJS setup
-/lib/js/src
-/lib/js/__tests__/*.bs.js
-## ES6 setup
-/lib/es6/src
-/lib/es6/__tests__/*.bs.js
+*.bs.js
+dist
 
 # Misc
 .DS_Store

--- a/src/templates/reason/index.js.ejs
+++ b/src/templates/reason/index.js.ejs
@@ -1,3 +1,3 @@
 require("./index.css");
-require("../lib/js/src/Index.bs");
+require("./Index.bs");
 

--- a/src/templates/reason/package.json.ejs
+++ b/src/templates/reason/package.json.ejs
@@ -18,29 +18,27 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "16.12.0",
-    "react-dom": "16.12.0",
-    "reason-react": "0.7.0"
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "reason-react": "0.9.1"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "2.0.4",
-    "@glennsl/bs-jest": "0.4.9",
-    "@semantic-release/changelog": "3.0.6",
-    "@semantic-release/git": "8.0.0",
-    "autoprefixer": "9.7.4",
-    "bs-jest-dom": "2.0.1",
-    "bs-platform": "7.0.1",
-    "bs-react-testing-library": "0.6.0",
-    "cross-env": "6.0.3",
-    "css-loader": "3.4.2",
-    "html-webpack-plugin": "3.2.0",
-    "is-ci-cli": "2.0.0",
+    "@glennsl/bs-jest": "0.5.1",
+    "@semantic-release/changelog": "5.0.1",
+    "@semantic-release/git": "9.0.0",
+    "autoprefixer": "9.8.6",
+    "bs-jest-dom": "4.1.1",
+    "bs-platform": "8.2.0",
+    "bs-react-testing-library": "0.7.3",
+    "cross-env": "7.0.2",
+    "css-loader": "4.2.2",
+    "html-webpack-plugin": "4.4.1",
+    "is-ci-cli": "2.1.2",
     "postcss-loader": "3.0.0",
-    "style-loader": "1.1.3",
-    "tailwindcss": "1.1.4",
-    "webpack": "4.41.5",
-    "webpack-cli": "3.3.10",
-    "webpack-dev-server": "3.10.1"
+    "style-loader": "1.2.1",
+    "tailwindcss": "1.7.6",
+    "webpack": "4.44.1",
+    "webpack-cli": "3.3.12",
+    "webpack-dev-server": "3.11.0"
   }
 }
-

--- a/src/templates/reason/postcss.config.js.ejs
+++ b/src/templates/reason/postcss.config.js.ejs
@@ -1,14 +1,3 @@
-const purgecss = require("@fullhuman/postcss-purgecss")({
-  content: ["./lib/**/*.js", "./src/index.css"],
-  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
-});
-
 module.exports = {
-  plugins: [
-    require("tailwindcss"),
-    require("autoprefixer"),
-    ...(process.env.NODE_ENV === "production" ? [purgecss] : [])
-  ]
+  plugins: [require("tailwindcss"), require("autoprefixer")],
 };
-
-

--- a/src/templates/reason/tailwind.config.js.ejs
+++ b/src/templates/reason/tailwind.config.js.ejs
@@ -1,0 +1,10 @@
+module.exports = {
+  purge: ["./src/**/*.bs.js"],
+  theme: {},
+  variants: {},
+  plugins: [],
+  future: {
+    removeDeprecatedGapUtilities: true,
+  },
+};
+

--- a/test/commands/reason.spec.ts
+++ b/test/commands/reason.spec.ts
@@ -86,17 +86,13 @@ test('installs app dependencies', async () => {
   })
 })
 
-test('setup for tailwind', async () => {
-  await reason({ name: 'test', flags: {} })
-
-  expect(execa).toHaveBeenCalledWith('npx', ['tailwind', 'init'], {
-    cwd: expect.stringMatching(/test/),
-  })
-})
-
 test('create tailwind config', async () => {
   await reason({ name: 'test', flags: {} })
 
+  expect(create).toHaveBeenCalledWith({
+    templateName: 'reason/tailwind.config.js',
+    output: 'test/tailwind.config.js',
+  })
   expect(create).toHaveBeenCalledWith({
     templateName: 'reason/postcss.config.js',
     output: 'test/postcss.config.js',


### PR DESCRIPTION
This PR updates the setup for `reason`:

- Update to `bs-platform@8.2.0` which adds [ReScript](http://rescript-lang.org/) support
- Set `"in-source": true` in `bsconfig.json` to render JavaScript files inline for better library support
- Set `purge` in `tailwind.config.js` as CSS purging is [now built-in](https://tailwindcss.com/docs/release-notes#tailwind-css-v1-4)
- Update all other dependencies